### PR TITLE
Allows rollup to parse json

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@babel/preset-typescript": "^7.10.4",
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^15.1.0",
+    "@rollup/plugin-json": "^4.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
     "babel-jest": "26.3.0",
     "babel-plugin-emotion": "^10.0.33",
@@ -47,7 +48,6 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
-    "@rollup/plugin-json": "^4.1.0",
     "@types/execa": "^2.0.0",
     "@types/is-ci": "^2.0.0",
     "@types/jest": "^26.0.15",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "yargs": "^15.3.1"
   },
   "devDependencies": {
+    "@rollup/plugin-json": "^4.1.0",
     "@types/execa": "^2.0.0",
     "@types/is-ci": "^2.0.0",
     "@types/jest": "^26.0.15",

--- a/src/configs/rollup.ts
+++ b/src/configs/rollup.ts
@@ -8,6 +8,7 @@ import postcss from "rollup-plugin-postcss";
 import peerDepsExternal from "rollup-plugin-peer-deps-external";
 import babelConfig from "./babel";
 import pkgDir from "pkg-dir";
+import json from "@rollup/plugin-json";
 import { extensions, extensionsWithDot } from "../extensions";
 
 const root = pkgDir.sync();
@@ -53,6 +54,7 @@ export const config: RollupOptions = {
       modules: false,
       use: ["sass"],
     }),
+    json(),
     babel({
       babelrc: false,
       babelHelpers: "runtime",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1272,6 +1272,13 @@
     magic-string "^0.25.7"
     resolve "^1.17.0"
 
+"@rollup/plugin-json@^4.1.0":
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-json/-/plugin-json-4.1.0.tgz#54e09867ae6963c593844d8bd7a9c718294496f3"
+  integrity sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.8"
+
 "@rollup/plugin-node-resolve@^9.0.0":
   version "9.0.0"
   resolved "https://registry.yarnpkg.com/@rollup/plugin-node-resolve/-/plugin-node-resolve-9.0.0.tgz#39bd0034ce9126b39c1699695f440b4b7d2b62e6"
@@ -1284,7 +1291,7 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
-"@rollup/pluginutils@^3.1.0":
+"@rollup/pluginutils@^3.0.8", "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"
   integrity sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==


### PR DESCRIPTION
## Summary
Created as a direct result of https://github.com/activeviam/activeui-5/pull/671. Currently, if any `activeui-5` package attempts to import a `.json` file, the build will fail with an `Unexpected syntax error 
";" ` as rollup attempts to compile the `.json` file as `.js` file. 

This PR adds support for `*.json` files at build time. 

Note: I tested this locally by making the changes in the local repo, compiling, and in `AUI-5` targeting the local package, instead of the `npm` version. After this, the build worked as expected. 