### PR TITLE
Make the jest config a default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@activeviam/scripts",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Scripts for developing React/TypeScript libraries.",
   "license": "MIT",
   "author": "ActiveViam",

--- a/src/configs/jest.ts
+++ b/src/configs/jest.ts
@@ -17,7 +17,7 @@ const ignores = [
   "__mocks__",
 ];
 
-export const config = {
+export default {
   roots: [path.join(root, "src")],
   testEnvironment: "jsdom",
   moduleFileExtensions: extensions,

--- a/src/scripts/test.ts
+++ b/src/scripts/test.ts
@@ -1,5 +1,5 @@
 import isCI from "is-ci";
-import { config as jestConfig } from "../configs/jest";
+import jestConfig from "../configs/jest";
 import jest = require("jest");
 
 export const test = async (args: string[]): Promise<void> => {


### PR DESCRIPTION
This will make it easier to reuse this config in other contexts such as running tests from vscode.